### PR TITLE
do not halt and catch fire when run under py2.6

### DIFF
--- a/scripts/check_python
+++ b/scripts/check_python
@@ -9,8 +9,8 @@ if hash python 2>/dev/null; then
 	python -c 'import sys
 minver2=7
 minver3=5
-vmaj = sys.version_info.major
-vmin = sys.version_info.minor
+vmaj = sys.version_info[0]
+vmin = sys.version_info[1]
 if (vmaj == 2 and vmin >= minver2) or (vmaj == 3 and vmin >= minver3):
     exit(0)
 print("""check-python: Python2 >= {} or Python3 >= {} not found (version reported by '{}' is '{}').


### PR DESCRIPTION
When run under python 2.6, the python version test logic would exit with a
non-zero exit status and a minimal python stack trace.

```
Traceback (most recent call last):
  File "<string>", line 4, in <module>
AttributeError: 'tuple' object has no attribute 'major'
```
